### PR TITLE
Fix Hash bug into function_behavior_ruby.rb on line 64

### DIFF
--- a/lib/kuniri/language/ruby/function_behavior_ruby.rb
+++ b/lib/kuniri/language/ruby/function_behavior_ruby.rb
@@ -30,7 +30,7 @@ module Languages
               functionRuby.add_parameters(parameter)
             end
           end
- 
+
           @log.write_log("Debug: Method: #{functionRuby.name}, Parameter:
                          #{functionRuby.parameters}")
 
@@ -61,7 +61,7 @@ module Languages
             if element =~ /=/
               parameter = element.scan(/(\w*)=/).join("")
               value = element.scan(/=(\w*)/).join("")
-              defaultParameter = Hash(parameter => value)
+              defaultParameter = {parameter => value}
               newList.push(defaultParameter)
               next
             end


### PR DESCRIPTION
Some tests were breaking because the declaration of Hash in the file: lib/kuniri/language/ruby/function_behavior_ruby.rb

ISSUE: Test problem #55
https://github.com/Kuniri/kuniri/issues/55
