### PR TITLE
[DEV] Refactoring add_global_variable

### DIFF
--- a/lib/kuniri/language/container_data/structured_and_oo/file_element.rb
+++ b/lib/kuniri/language/container_data/structured_and_oo/file_element.rb
@@ -38,9 +38,9 @@ module Languages
       end
 
       # Add global variable inside file.
-      # @param pVariable An VariableGlobalData object to be added.
-      def add_global_variable(pVariable)
-        pVariable.each do |element|
+      # @param pVariable A single VariableGlobalData object or list to be added.
+      def add_global_variable(*pVariable)
+        pVariable.flatten.each do |element|
           next unless element.is_a?(Languages::VariableGlobalData)
           @global_variables.push(element)
         end

--- a/spec/language/container_data/structured_and_oo/file_element_spec.rb
+++ b/spec/language/container_data/structured_and_oo/file_element_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Languages::FileElement do
     @globalFunction2 = Languages::FunctionData.new("second")
     @globalVariable1 = [Languages::VariableGlobalData.new("var1")]
     @globalVariable2 = [Languages::VariableGlobalData.new("var2")]
+    @globalVariable3 = Languages::VariableGlobalData.new("var3")
     @externFile1 = Languages::ExternRequirementData.new ("/dir/1")
     @externFile2 = Languages::ExternRequirementData.new ("/dir/2")
     @class1 = Languages::ClassData.new
@@ -52,6 +53,11 @@ RSpec.describe Languages::FileElement do
         variables.push(variable.name)
       end
       expect(variables).to match_array(["var1", "var2"])
+    end
+
+    it "Add one global variable as single parameter." do
+      @fileElement.add_global_variable(@globalVariable3)
+      expect(@fileElement.global_variables[0].name == "var3").to be true
     end
 
     it "Add non global variable." do


### PR DESCRIPTION
In order to make the method accept either a single value or an Array, an optional
parameter was chosen. This was used in order to avoid checking if pVariable is
an Array or not. It also must be said that the faltten method was used on
pVariable, since optional parameters in ruby are already an Array by default,
therefore, if the user pass an Array as parameter, without the flatten call,
pVariable would be an Array of an Array.

This commit closes #61

Signed-off-by: Lucas Moura lucas.moura128@gmail.com
