### PR TITLE
Raise exception on empty filePath

### DIFF
--- a/lib/kuniri/parser/parser.rb
+++ b/lib/kuniri/parser/parser.rb
@@ -23,7 +23,9 @@ module Parser
 
         # Start parse in the project.
         def start_parser
-          # TODO: handle the case of filePAth is empty
+          # TODO: handle the case of filePath is empty
+          raise Error::ConfigurationFileError if(@filesPath.empty?)
+
           @log.write_log("Debug: START FIRST PARSER")
           @filesPath.each do |file|
             language = @factory.get_language(@language)

--- a/lib/kuniri/parser/parser.rb
+++ b/lib/kuniri/parser/parser.rb
@@ -23,8 +23,10 @@ module Parser
 
         # Start parse in the project.
         def start_parser
-          # TODO: handle the case of filePath is empty
-          raise Error::ConfigurationFileError if(@filesPath.empty?)
+          if (@filesPath.empty?)
+            @log.write_log("Error: FilePath can not be empty")
+            raise Error::ConfigurationFileError
+          end
 
           @log.write_log("Debug: START FIRST PARSER")
           @filesPath.each do |file|

--- a/spec/parser/parser_spec.rb
+++ b/spec/parser/parser_spec.rb
@@ -16,6 +16,13 @@ RSpec.describe Parser::Parser do
       @parser.start_parser
       expect(@parser.fileLanguage.size).to eq(@filesProject.size)
     end
+
+    it "Try a empty file path" do
+      @filesProject = ""
+      @parser = Parser::Parser.new(@filesProject)
+      expect{@parser.start_parser}.to raise_error(
+        Error::ConfigurationFileError)
+    end
   end
 
   after :each do


### PR DESCRIPTION
Raise a ConfigurationFileError when start parser gets a empty filePath.

This closes issue https://github.com/Kuniri/kuniri/issues/88
