### PR TITLE
Kuniri run in a single file and tests the final output of kuniri

### DIFF
--- a/lib/kuniri/core/kuniri.rb
+++ b/lib/kuniri/core/kuniri.rb
@@ -31,7 +31,7 @@ module Kuniri
         @log.write_log("info: Kuniri object successfully created.")
       end
 
-      # Start Kuniri tasks based on configuration file. After read 
+      # Start Kuniri tasks based on configuration file. After read
       # configuration file, find all files in source directory.
       def run_analysis()
         @log.write_log("info: Start to run analysis.")
@@ -43,12 +43,13 @@ module Kuniri
           @log.write_log("Prolblem when tried to access source folder.")
           return -1
         end
-
         @log.write_log("debug: files: #{@filesPathProject.to_s}")
+		puts @filesPathProject
         @parser = Parser::Parser.new(@filesPathProject)
-        @parser.start_parser()
+	    @parser.start_parser()
+		puts "+" * 40
       end
- 
+
       def get_parser
         @parser
       end
@@ -64,11 +65,19 @@ module Kuniri
       # !@param pPath Relative path of the project.
       # !@param pLanguage Language extension for make the parser.
       def get_project_file(pPath="./", pLanguage="**.rb")
-        return nil unless File.exists?(pPath)
+		# Verify if path is a valid directory or file
+		return nil unless File.file?(pPath) or File.directory?(pPath)
+
+		# Handle single file
+		if (File.file?(pPath))
+			@filesProject = [pPath]
+		# Handle multiple files
+		else
+        	@filesProject = Dir[File.join(pPath, "**", pLanguage)]
+		end
 
         @log.write_log("Info: Reading all files.")
-
-        @filesProject = Dir[File.join(pPath, "**", pLanguage)]
+		return @filesProject
       end
 
   # Class

--- a/lib/kuniri/core/kuniri.rb
+++ b/lib/kuniri/core/kuniri.rb
@@ -44,10 +44,8 @@ module Kuniri
           return -1
         end
         @log.write_log("debug: files: #{@filesPathProject.to_s}")
-		puts @filesPathProject
         @parser = Parser::Parser.new(@filesPathProject)
-	    @parser.start_parser()
-		puts "+" * 40
+  	    @parser.start_parser()
       end
 
       def get_parser

--- a/lib/kuniri/core/setting.rb
+++ b/lib/kuniri/core/setting.rb
@@ -36,10 +36,10 @@ module Kuniri
         end
 
       end
- 
+
       # Read the configuration file and return a list with the configurations.
       # In this method it is checked the configuration file syntax.
-      # @param pPath [String] Path to ".kuniri" file, it means, the 
+      # @param pPath [String] Path to ".kuniri" file, it means, the
       #         configurations.
       # @return [Hash] Return a Hash with the configurations read in ".kuniri",
       #     otherwise, raise an exception.
@@ -105,8 +105,11 @@ module Kuniri
             # @log.write_log("Syntax error on configuration file.")
             raise Error::ConfigurationFileError
           end
-          key = handling_basic_syntax(line, 0)
+          key = handling_basic_syntax(line, 0).downcase
           value = handling_basic_syntax(line, 1)
+          unless key == "source" or key == "output"
+            value.downcase!
+          end
           configuration[key] = value
         end
         return configuration
@@ -122,7 +125,7 @@ module Kuniri
       end
 
       def handling_basic_syntax(pLine, pIndex)
-        text = pLine.split(':')[pIndex].downcase
+        text = pLine.split(':')[pIndex]
         text.gsub!(/\s/, '')
         return text
       end

--- a/spec/language/ruby/global_test/.kuniri
+++ b/spec/language/ruby/global_test/.kuniri
@@ -1,4 +1,0 @@
-language:ruby
-source:/home/filipe/Documentos/ruby/kuniri_project/kuniri_dev/kuniri/spec/language/ruby/global_test/
-output:/home/filipe/Documentos/ruby/kuniri_project/kuniri_dev/kuniri/spec/language/ruby/global_test/
-extract:uml

--- a/spec/language/ruby/global_test/.kuniri
+++ b/spec/language/ruby/global_test/.kuniri
@@ -1,0 +1,4 @@
+language:ruby
+source:./spec/samples/rubySyntaxParts/fullCode/simpleFullCode.rb
+output:./spec
+extract:uml

--- a/spec/language/ruby/global_test/.kuniri
+++ b/spec/language/ruby/global_test/.kuniri
@@ -1,0 +1,4 @@
+language:ruby
+source:/home/filipe/Documentos/ruby/kuniri_project/kuniri_dev/kuniri/spec/language/ruby/global_test/
+output:/home/filipe/Documentos/ruby/kuniri_project/kuniri_dev/kuniri/spec/language/ruby/global_test/
+extract:uml

--- a/spec/language/ruby/global_test/complete_class_ruby_spec.rb
+++ b/spec/language/ruby/global_test/complete_class_ruby_spec.rb
@@ -112,6 +112,25 @@ RSpec.describe Kuniri::Kuniri do
     expect(@parameters.size).to eq(4)
   end
 
+  it "Should contain the inheritance name" do
+    @inheritance_name = nil
+    @output.each do |line|
+      @inheritance_name = line =~ /\s+<inheritance\sname="Array"\/>/
+      break unless @inheritance_name.nil?
+    end
+    expect(@inheritance_name).not_to be_nil
+  end
+
+
+  it "Should find all inheritances" do
+    @inheritance = []
+    @output.each do |line|
+      line_of_inheritance = line =~ /\s+<inheritance\sname="\w+"\/>/
+      @inheritance << line_of_inheritance unless line_of_inheritance.nil?
+    end
+    expect(@inheritance.size).to eq(1)
+  end
+
   it "Should verify the opening-closing structure" do
     @stack = []
     @output.each do |line|

--- a/spec/language/ruby/global_test/complete_class_ruby_spec.rb
+++ b/spec/language/ruby/global_test/complete_class_ruby_spec.rb
@@ -3,18 +3,20 @@ require_relative '../../../../lib/kuniri/core/kuniri'
 RSpec.describe Kuniri::Kuniri do
 
   before :each do
-    @path = "/spec/language/ruby/global_test/.kuniri"  
+    @path = "/spec/language/ruby/global_test/kuniri-config"
     @kuniri = Kuniri::Kuniri.new(@path)
   end
 
   it "Correct structure of class - Class" do
-    pLanguage ="**.rb"
-    @filesProject = Dir[File.join(@path, "**", pLanguage)]
+    #pLanguage ="**.rb"
+    #@filesProject = Dir[File.join(@path, "**", pLanguage)]
 
-    @parser = Parser::Parser.new(@filesProject)
-    @parser.start_parser()
+    #@parser = Parser::Parser.new(@filesProject)
+    #@parser.start_parser()
+    @kuniri.run_analysis
 
     parser = Parser::XML.new
+    parser.set_path("./spec/language/ruby/global_test/output_test.xml")
     parser.create_all_data @kuniri.get_parser()
   end
 

--- a/spec/language/ruby/global_test/complete_class_ruby_spec.rb
+++ b/spec/language/ruby/global_test/complete_class_ruby_spec.rb
@@ -39,21 +39,24 @@ RSpec.describe Kuniri::Kuniri do
   it "Should contain the method name and visibility" do
     @method_name = nil
     @output.each do |line|
-      @method_name = line =~ /\s+<method\sname="method1"\svisibility="global"\/?>/
+      @method_name = line =~ 
+      /\s+<method\sname="method1"\svisibility="global"\/?>/
       break unless @method_name.nil?
     end
     expect(@method_name).not_to be_nil
 
     @method_name = nil
     @output.each do |line|
-      @method_name = line =~ /\s+<method\sname="method2"\svisibility="global"\/?>/
+      @method_name = line =~ 
+      /\s+<method\sname="method2"\svisibility="global"\/?>/
       break unless @method_name.nil?
     end
     expect(@method_name).not_to be_nil
 
     @method_name = nil
     @output.each do |line|
-      @method_name = line =~ /\s+<method\sname="method3"\svisibility="global"\/?>/
+      @method_name = line =~ 
+      /\s+<method\sname="method3"\svisibility="global"\/?>/
       break unless @method_name.nil?
     end
     expect(@method_name).not_to be_nil
@@ -62,7 +65,8 @@ RSpec.describe Kuniri::Kuniri do
   it "Should find all methods" do
     @methods = []
     @output.each do |line|
-      line_of_method = line =~ /\s+<method\sname="method\d"\svisibility="global"\/?>/
+      line_of_method = line =~ 
+      /\s+<method\sname="method\d"\svisibility="global"\/?>/
       @methods << line_of_method unless line_of_method.nil?
     end
     expect(@methods.size).to eq(3)
@@ -108,7 +112,25 @@ RSpec.describe Kuniri::Kuniri do
     expect(@parameters.size).to eq(4)
   end
 
+  it "Should verify the opening-closing structure" do
+    @stack = []
+    @output.each do |line|
+      next if line =~ /<\?xml.*/
+      next if line =~ /.*\/>/
 
+      if line =~ /\s*<\/(\w*)>/
+        expect(@stack.last).to eq($1)
+        @stack.pop
+
+      elsif line =~ /\s*<(\w*)(.*)>/
+        @stack.push $1
+      end      
+  
+    end
+
+    expect(@stack.size).to eq(0)
+
+  end
 
   after :each do
     @kuniri = nil

--- a/spec/language/ruby/global_test/complete_class_ruby_spec.rb
+++ b/spec/language/ruby/global_test/complete_class_ruby_spec.rb
@@ -3,25 +3,116 @@ require_relative '../../../../lib/kuniri/core/kuniri'
 RSpec.describe Kuniri::Kuniri do
 
   before :each do
-    @path = "/spec/language/ruby/global_test/kuniri-config"
+    @path = "./spec/language/ruby/global_test/.kuniri"
     @kuniri = Kuniri::Kuniri.new(@path)
-  end
-
-  it "Correct structure of class - Class" do
-    #pLanguage ="**.rb"
-    #@filesProject = Dir[File.join(@path, "**", pLanguage)]
-
-    #@parser = Parser::Parser.new(@filesProject)
-    #@parser.start_parser()
     @kuniri.run_analysis
 
     parser = Parser::XML.new
     parser.set_path("./spec/language/ruby/global_test/output_test.xml")
     parser.create_all_data @kuniri.get_parser()
+    @output = File.open("./spec/language/ruby/global_test/output_test.xml", "r")
   end
 
+  it "Should contain the class name" do
+    @class_name = nil
+    @output.each do |line|
+      @class_name = line =~ /\s+<class_data\sname="Abc">/
+      break unless @class_name.nil?
+    end
+    expect(@class_name).not_to be_nil
+    @class_end = nil
+    @output.each do |line|
+      @class_end = line =~ /\s+<\/class_data>$/
+      break unless @class_end.nil?
+    end
+    expect(@class_end).not_to be_nil
+  end
+
+  it "Should contain constructor" do
+    @constructor = nil
+    @output.each do |line|
+      @class_name = line =~ /\s+<method\sname="initialize"\/?>/
+      break unless @class_name.nil?
+    end
+  end
+
+  it "Should contain the method name and visibility" do
+    @method_name = nil
+    @output.each do |line|
+      @method_name = line =~ /\s+<method\sname="method1"\svisibility="global"\/?>/
+      break unless @method_name.nil?
+    end
+    expect(@method_name).not_to be_nil
+
+    @method_name = nil
+    @output.each do |line|
+      @method_name = line =~ /\s+<method\sname="method2"\svisibility="global"\/?>/
+      break unless @method_name.nil?
+    end
+    expect(@method_name).not_to be_nil
+
+    @method_name = nil
+    @output.each do |line|
+      @method_name = line =~ /\s+<method\sname="method3"\svisibility="global"\/?>/
+      break unless @method_name.nil?
+    end
+    expect(@method_name).not_to be_nil
+  end
+
+  it "Should find all methods" do
+    @methods = []
+    @output.each do |line|
+      line_of_method = line =~ /\s+<method\sname="method\d"\svisibility="global"\/?>/
+      @methods << line_of_method unless line_of_method.nil?
+    end
+    expect(@methods.size).to eq(3)
+  end
+
+  it "Should contain the parameter name" do
+    @parameter_name = nil
+    @output.each do |line|
+      @parameter_name = line =~ /\s+<parameter\sname="x"\/>/
+      break unless @parameter_name.nil?
+    end
+    expect(@parameter_name).not_to be_nil
+
+    @parameter_name = nil
+    @output.each do |line|
+      @parameter_name = line =~ /\s+<parameter\sname="a"\/>/
+      break unless @parameter_name.nil?
+    end
+    expect(@parameter_name).not_to be_nil
+
+    @parameter_name = nil
+    @output.each do |line|
+      @parameter_name = line =~ /\s+<parameter\sname="b"\/>/
+      break unless @parameter_name.nil?
+    end
+    expect(@parameter_name).not_to be_nil
+
+    @parameter_name = nil
+    @output.each do |line|
+      @parameter_name = line =~ /\s+<parameter\sname="c"\/>/
+      break unless @parameter_name.nil?
+    end
+    expect(@parameter_name).not_to be_nil
+  end
+
+
+  it "Should find all parameters" do
+    @parameters = []
+    @output.each do |line|
+      line_of_parameter = line =~ /\s+<parameter\sname="\w+"\/>/
+      @parameters << line_of_parameter unless line_of_parameter.nil?
+    end
+    expect(@parameters.size).to eq(4)
+  end
+
+
+
   after :each do
-    
+    @kuniri = nil
+    @output = nil
   end
 
 end

--- a/spec/language/ruby/global_test/complete_class_ruby_spec.rb
+++ b/spec/language/ruby/global_test/complete_class_ruby_spec.rb
@@ -1,0 +1,25 @@
+require_relative '../../../../lib/kuniri/core/kuniri'
+
+RSpec.describe Kuniri::Kuniri do
+
+  before :each do
+    @path = "/spec/language/ruby/global_test/.kuniri"  
+    @kuniri = Kuniri::Kuniri.new(@path)
+  end
+
+  it "Correct structure of class - Class" do
+    pLanguage ="**.rb"
+    @filesProject = Dir[File.join(@path, "**", pLanguage)]
+
+    @parser = Parser::Parser.new(@filesProject)
+    @parser.start_parser()
+
+    parser = Parser::XML.new
+    parser.create_all_data @kuniri.get_parser()
+  end
+
+  after :each do
+    
+  end
+
+end

--- a/spec/samples/rubySyntaxParts/fullCode/simpleFullCode.rb
+++ b/spec/samples/rubySyntaxParts/fullCode/simpleFullCode.rb
@@ -1,17 +1,25 @@
 @globalVariable
 
-class Abc
+class Abc < Array
 
   def initialize
   end
 
   def method1
+  	while condition do
+  		
+  	end
   end
 
   def method2 (x)
+  	for i in x
+  	end
   end
 
   def method3 (a, b, c)
+  	if (a==0)
+  		return b < c
+  	end
   end
 
   @attribute1


### PR DESCRIPTION
- Kuniri now run in a single file if specified in the configuration file, with a path to a file instead of a directory
- Add test that run kuniri in a sample ruby class and compare the output with the expected structure

This closes the issue https://github.com/Kuniri/kuniri/issues/71
