### PR TITLE
Adding tests for inheritance name

### DIFF
--- a/spec/language/ruby/class_ruby_spec.rb
+++ b/spec/language/ruby/class_ruby_spec.rb
@@ -64,34 +64,69 @@ RSpec.describe Languages::Ruby::ClassRuby do
   end
 
   context "When with inheritance" do
-    it "Simple class inheritance." do
+    it "Simple class name w/ inheritance." do
       classNameCaptured = @classRuby.get_class("class Xpto < Abc").name
       expect(classNameCaptured).to eq("Xpto")
     end
 
-    it "Class inheritance with whitespace in the beginning." do
+    it "Simple class inheritance." do
+      classNameCaptured = @classRuby.get_class("class Xpto < Abc").inheritances
+      expect(classNameCaptured).to eq([["Abc"]])
+    end
+
+    it "Class name w/ inheritance with whitespace in the beginning." do
       classNameCaptured = @classRuby.get_class("     class   Xpto < Abc").name
       expect(classNameCaptured).to eq("Xpto")
     end
 
-    it "Class inheritance with whitespace between <." do
+    it "Class inheritance with whitespace in the beginning." do
+      classNameCaptured = @classRuby.get_class("     class   Xpto < Abc")
+                                    .inheritances
+      expect(classNameCaptured).to eq([["Abc"]])
+    end
+
+    it "Class name w/ inheritance with whitespace between <." do
       classNameCaptured = @classRuby.get_class("class Xpto   < Abc").name
       expect(classNameCaptured).to eq("Xpto")
     end
 
-    it "Class inheritance with many whitespace." do
+    it "Class inheritance with whitespace between <." do
+      classNameCaptured = @classRuby.get_class("class Xpto   < Abc")
+                                    .inheritances
+      expect(classNameCaptured).to eq([["Abc"]])
+    end
+
+    it "Class name w/ inheritance with many whitespace." do
       classNameCaptured = @classRuby.get_class("   class   Xpto < Abc ").name
       expect(classNameCaptured).to eq("Xpto")
     end
 
-    it "Class inheritance with many whitespace between <." do
+    it "Class inheritance with many whitespace." do
+      classNameCaptured = @classRuby.get_class("   class   Xpto < Abc ")
+                                    .inheritances
+      expect(classNameCaptured).to eq([["Abc"]])
+    end
+
+    it "Class name w/ inheritance with many whitespace between <." do
       classNameCaptured = @classRuby.get_class("class Xpto      <    Abc").name
       expect(classNameCaptured).to eq("Xpto")
     end
 
-    it "Class inheritance with whitespace in the corners." do
+    it "Class inheritance with many whitespace between <." do
+      classNameCaptured = @classRuby.get_class("class Xpto      <    Abc")
+                                    .inheritances
+      expect(classNameCaptured).to eq([["Abc"]])
+    end
+
+    it "Class name w/ inheritance with whitespace in the corners." do
       classNameCaptured = @classRuby.get_class("  class   Xpto < Abc   ").name
       expect(classNameCaptured).to eq("Xpto")
+    end
+
+    it "Class inheritance with whitespace in the corners." do
+      classNameCaptured = @classRuby.get_class("  class   Xpto < Abc   ")
+                                    .inheritances
+      expect(classNameCaptured).to eq([["Abc"]])
     end
   end
 


### PR DESCRIPTION
Additionaly, the class_ruby.rb got the inheritance name with spaces. This was fixed.
