### PR TITLE
Fixed class inhereritance issue

### DIFF
--- a/lib/kuniri/language/ruby/class_ruby.rb
+++ b/lib/kuniri/language/ruby/class_ruby.rb
@@ -43,7 +43,6 @@ module Languages
       def get_inheritance(pString)
         if pString =~ /</
           partial = pString.split('<').last.strip
-          partial = partial.split('::').last.strip
           return partial
         end
 

--- a/spec/language/ruby/class_ruby_spec.rb
+++ b/spec/language/ruby/class_ruby_spec.rb
@@ -132,25 +132,25 @@ RSpec.describe Languages::Ruby::ClassRuby do
     it 'Class inheritance with module namespace' do
       classNameCaptured = @classRuby.get_class('class Xpto < lalala::Abc')
                                     .inheritances
-      expect(classNameCaptured).to match_array(['Abc'])
+      expect(classNameCaptured).to match_array(['lalala::Abc'])
     end
 
     it 'Class inheritance with multiple module namespace' do
       classNameCaptured = @classRuby.get_class('class Xpto < lu::la::lo::Abc')
                                     .inheritances
-      expect(classNameCaptured).to match_array(['Abc'])
+      expect(classNameCaptured).to match_array(['lu::la::lo::Abc'])
     end
 
     it 'Class inheritance with module namespace and spaces' do
       classNameCaptured = @classRuby.get_class(' class Xpto < lalala::Abc  ')
                                     .inheritances
-      expect(classNameCaptured).to match_array(['Abc'])
+      expect(classNameCaptured).to match_array(['lalala::Abc'])
     end
 
     it 'Class inheritance with module namespace and spaces before module' do
       classNameCaptured = @classRuby.get_class(' class Xpto  <   lalala::Abc ')
                                     .inheritances
-      expect(classNameCaptured).to match_array(['Abc'])
+      expect(classNameCaptured).to match_array(['lalala::Abc'])
     end
   end
 


### PR DESCRIPTION
Instead of mehtod get_inheritance of class_ruby.rb file return just the class name of the inherited class, it also returns the module and namespace names. Also changed the tests of this feature.