### PR TITLE
Fixed error of running kuniri on empty folder

### DIFF
--- a/lib/kuniri/core/kuniri.rb
+++ b/lib/kuniri/core/kuniri.rb
@@ -59,7 +59,11 @@ module Kuniri
       @parser = Parser::Parser.new(@filesPathProject,
                                    @configurationInfo[:language])
       Util::LoggerKuniri.info('Start parse...')
-      @parser.start_parser
+      begin
+        @parser.start_parser
+      rescue Error::ConfigurationFileError => e
+        puts e.message
+      end
     end
 
     def get_parser

--- a/spec/core/kuniri_spec.rb
+++ b/spec/core/kuniri_spec.rb
@@ -1,5 +1,5 @@
 require_relative '../spec_helper'
-
+require 'fileutils'
 RSpec.describe Kuniri::Kuniri do
 
   context "When path for run_analysis is wrong." do
@@ -10,6 +10,34 @@ RSpec.describe Kuniri::Kuniri do
       folderFiles = Dir[File.join("./", "**", "**.rb")]
       expect(defaultPath).to match_array(folderFiles)
     end
+
   end
 
+  context "When source directory is empty" do
+    before :each do
+      if Dir.exists?('empty_directory')
+        FileUtils.rm_rf('empty_directory')
+      end      
+      FileUtils.mkdir('empty_directory')
+    end
+
+    it "Should not crash" do
+
+      @kuniriTest = Kuniri::Kuniri.new
+      @kuniriTest.set_configuration('./empty_directory/', 'ruby', 'output_dir', 0)
+
+      begin
+        expect {@kuniriTest.run_analysis}.not_to raise_error
+      rescue => e
+        expect(e).not_to be_a(Error::ConfigurationFileError)
+      end
+
+    end
+    after :each do
+      if Dir.exists?('output_dir')
+        FileUtils.rm_rf('output_dir')
+      end
+      FileUtils.rm_rf('empty_directory')
+    end
+  end
 end


### PR DESCRIPTION
Fixed issue by handling the error raised when running kuniri on empty directories