### PR TITLE
rubocop.yml: increase AbcSize metric to 22

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -45,7 +45,7 @@ Metrics/LineLength:
 
 # Offense count: 86
 Metrics/AbcSize:
-  Max: 19
+  Max: 22
 
 # Offense count: 32
 # Configuration parameters: CountComments.


### PR DESCRIPTION
In file ruby_syntax.rb the issue raised by rubocop
on initialize method does not make any sense. This
method just initialize parameters, thus we prefer
increase the accepted AbcSize metric.

Closes #208

Signed-off-by: Lucas Kanashiro <kanashiro@debian.org>
Signed-off-by: Bruno Sesso <bruno.sesso@usp.br>
Signed-off-by: Giuliano Belinassi <giuliano.belinassi@usp.br>