### PR TITLE
do not break when kuniri is launched without args

### DIFF
--- a/bin/kuniri
+++ b/bin/kuniri
@@ -110,6 +110,7 @@ class OptparseKuniri
 end  # class OptparseKuniri
 
 def main
+  ARGV[0] = "-h" if ARGV[0] == nil
   options = OptparseKuniri.parse(ARGV)
 
   Util::LoggerKuniri.update_log_level(options.verbose_level)


### PR DESCRIPTION
Calling kuniri wihout any arguments crashed kuniri when a help message was expected.

Signed-off-by: giulianobelinassi <giuliano.belinassi@usp.br>
Signed-off-by: Lucas Kanashiro <kanashiro@debian.org>